### PR TITLE
Allow case insensitive input for gif command

### DIFF
--- a/gitter_bot.rb
+++ b/gitter_bot.rb
@@ -52,7 +52,7 @@ class GitterBot
     p "Target room = #{target_room}" if @debug
 	  if @message['text'].downcase.include? 'tell a joke'
 	  	tell_a_joke(target_room)
-	  elsif @message['text'].start_with? 'gif'
+	  elsif @message['text'].downcase.start_with? 'gif'
 	  	show_gif(target_room, @message['text'])
     elsif @message['text'].downcase.start_with? 'deactivate time service'
       toggle_time_service(target_room, false)


### PR DESCRIPTION
This will let the bot understand commands like:

`GIF ANGRY`
`Gif autocorrect`
`gIF why not`

Thanks for reviewing!